### PR TITLE
contentfilter/DocxParsing.py: Fixed a little compatibility flaw with python-docx library

### DIFF
--- a/emailidx/contentfilter/DocxParsing.py
+++ b/emailidx/contentfilter/DocxParsing.py
@@ -51,7 +51,7 @@ def get_docx_as_text(docx_data):
     """
     in_stream = StringIO.StringIO(buf=docx_data)
     document = Document(in_stream)
-    root_doc_part = document._document_part.body
+    root_doc_part = document._body
     docx_as_text = _get_docx_part_as_text(root_doc_part)
     in_stream.close()
     return docx_as_text

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='emailidx',
-    version='0.2.0',
+    version='0.2.1',
 
     description='Synchronizes emails from IMAP to Elasticsearch',
     author='Paul Hofmann',


### PR DESCRIPTION
… that blows up from instance to instance.
